### PR TITLE
Cached colormap minmax

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -789,8 +789,8 @@ class Colormap(qt.QObject):
             reference = data
         vmin, vmax = self.getColormapRange(reference)
 
-        if hasattr(data, "_getColormappedData"):  # Use item's data
-            data = data._getColormappedData()
+        if hasattr(data, "getColormappedData"):  # Use item's data
+            data = data.getColormappedData()
 
         normalization = self.getNormalization()
         return _cmap(data, self._colors, vmin, vmax, normalization)

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -593,8 +593,12 @@ class Colormap(qt.QObject):
         self._editable = editable
         self.sigChanged.emit()
 
-    def computeDataRange(self, data):
-        """Compute the data range which will be used in auto scale mode."""
+    def _computeAutoscaleRange(self, data):
+        """Compute the data range which will be used in autoscale mode.
+
+        :param numpy.ndarray data: The data for which to compute the range
+        :return: (vmin, vmax) range (vmin and /or vmax might be `None`)
+        """
         if data is None:
             return None, None
         if data.size == 0:
@@ -609,11 +613,11 @@ class Colormap(qt.QObject):
         return vMin, vMax
 
     def getColormapRange(self, data=None):
-        """Return (vmin, vmax)
+        """Return (vmin, vmax) the range of the colormap for the given data or item.
 
-        :param Union[numpy.ndarray,ColormapMixIn] data: The data to check.
-        :return: the tuple vmin, vmax fitting vmin, vmax, normalization and
-            data if any given
+        :param Union[numpy.ndarray,~silx.gui.plot.items.ColormapMixIn] data:
+            The data or item to use for autoscale bounds.
+        :return: (vmin, vmax) corresponding to the colormap applied to data if provided.
         :rtype: tuple
         """
         vmin = self._vmin
@@ -634,11 +638,11 @@ class Colormap(qt.QObject):
         if vmin is None or vmax is None:  # Handle autoscale
             # Get min/max from data
             if data is not None:
-                if hasattr(data, "getDataAutoRange"):
-                    min_, max_ = data.getDataAutoRange(self)
+                if hasattr(data, "_getColormapAutoscaleRange"):
+                    min_, max_ = data._getColormapAutoscaleRange(self)
                 else:
                     data = numpy.array(data, copy=False)
-                    min_, max_ = self.computeDataRange(data)
+                    min_, max_ = self._computeAutoscaleRange(data)
                 # Handle fallback
                 if min_ is None or not numpy.isfinite(min_):
                     min_ = self._getDefaultMin()
@@ -776,19 +780,20 @@ class Colormap(qt.QObject):
     def applyToData(self, data, reference=None):
         """Apply the colormap to the data
 
-        :param Union[numpy.ndarray,ColormapMixIn] data: The data to convert.
-        :param Union[numpy.ndarray,silx.gui.plot.item.Item,None] reference: The
-            data to use as reference in case of autoscale
+        :param Union[numpy.ndarray,~silx.gui.plot.item.ColormapMixIn] data:
+            The data to convert or the item for which to apply the colormap.
+        :param Union[numpy.ndarray,~silx.gui.plot.item.ColormapMixIn,None] reference:
+            The data or item to use as reference to compute autoscale
         """
         if reference is None:
             reference = data
         vmin, vmax = self.getColormapRange(reference)
+
+        if hasattr(data, "_getColormappedData"):  # Use item's data
+            data = data._getColormappedData()
+
         normalization = self.getNormalization()
-        if hasattr(data, "_getDataForAutoRange"):
-            array = data._getDataForAutoRange()
-        else:
-            array = data
-        return _cmap(array, self._colors, vmin, vmax, normalization)
+        return _cmap(data, self._colors, vmin, vmax, normalization)
 
     @staticmethod
     def getSupportedColormaps():

--- a/silx/gui/plot/items/complex.py
+++ b/silx/gui/plot/items/complex.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -191,6 +191,8 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
             colormap = self._colormaps[self.getComplexMode()]
             if colormap is not super(ImageComplexData, self).getColormap():
                 super(ImageComplexData, self).setColormap(colormap)
+
+            self._setColormappedData(self.getData(copy=False), copy=False)
         return changed
 
     def _setAmplitudeRangeInfo(self, max_=None, delta=2):
@@ -260,6 +262,7 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
 
         self._data = data
         self._dataByModesCache = {}
+        self._setColormappedData(self.getData(copy=False), copy=False)
 
         # TODO hackish data range implementation
         if self.isVisible():
@@ -358,6 +361,3 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
     @deprecated(replacement='getComplexMode', since_version='0.11.0')
     def getVisualizationMode(self):
         return self.getComplexMode()
-
-    def _getDataForAutoRange(self):
-        return self.getData(copy=False)

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -482,7 +482,8 @@ class ColormapMixIn(ItemMixInBase):
         """Handle updates of the colormap"""
         self._updated(ItemChangedType.COLORMAP)
 
-    def _setColormappedData(self, data, copy=True):
+    def _setColormappedData(self, data, copy=True,
+                            min_=None, minPositive=None, max_=None):
         """Set the data used to compute the colormapped display.
 
         It also resets the cache of data ranges.
@@ -490,9 +491,21 @@ class ColormapMixIn(ItemMixInBase):
         This method MUST be called by inheriting classes when data is updated.
 
         :param Union[None,numpy.ndarray] data:
+        :param Union[None,float] min_: Minimum value of the data
+        :param Union[None,float] minPositive:
+            Minimum of strictly positive values of the data
+        :param Union[None,float] max_: Maximum value of the data
         """
+        # TODO store min, minPositive, max
         self.__data = None if data is None else numpy.array(data, copy=copy)
         self.__cacheColormapRange = {}  # Reset cache
+
+        # Fill-up colormap range cache if values are provided
+        if max_ is not None and numpy.isfinite(max_):
+            if min_ is not None and numpy.isfinite(min_):
+                self.__cacheColormapRange[Colormap.LINEAR] = min_, max_
+            if minPositive is not None and numpy.isfinite(minPositive):
+                self.__cacheColormapRange[Colormap.LOGARITHM] = minPositive, max_
 
         colormap = self.getColormap()
         if None in (colormap.getVMin(), colormap.getVMax()):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -496,7 +496,6 @@ class ColormapMixIn(ItemMixInBase):
             Minimum of strictly positive values of the data
         :param Union[None,float] max_: Maximum value of the data
         """
-        # TODO store min, minPositive, max
         self.__data = None if data is None else numpy.array(data, copy=copy)
         self.__cacheColormapRange = {}  # Reset cache
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -454,7 +454,8 @@ class ColormapMixIn(ItemMixInBase):
     def __init__(self):
         self._colormap = Colormap()
         self._colormap.sigChanged.connect(self._colormapChanged)
-        self._cachedDataRange = None
+        self.__data = None
+        self.__cacheColormapRange = {}  # Store {normalization: range}
 
     def getColormap(self):
         """Return the used colormap"""
@@ -481,30 +482,50 @@ class ColormapMixIn(ItemMixInBase):
         """Handle updates of the colormap"""
         self._updated(ItemChangedType.COLORMAP)
 
-    def getDataAutoRange(self, colormap=None):
-        """Returns the auto range fitting the the data and the colormap
-        configuration."""
+    def _setColormappedData(self, data, copy=True):
+        """Set the data used to compute the colormapped display.
+
+        It also resets the cache of data ranges.
+
+        This method MUST be called by inheriting classes when data is updated.
+
+        :param Union[None,numpy.ndarray] data:
+        """
+        self.__data = None if data is None else numpy.array(data, copy=copy)
+        self.__cacheColormapRange = {}  # Reset cache
+
+    def _getColormappedData(self, copy=True):
+        """Returns the data used to compute the displayed colors
+
+        :param bool copy: True to get a copy,
+            False to get internal data (do not modify!).
+        :rtype: Union[None,numpy.ndarray]
+        """
+        if self.__data is None:
+            return None
+        else:
+            return numpy.array(self.__data, copy=copy)
+
+    def _getColormapAutoscaleRange(self, colormap=None):
+        """Returns the autoscale range for current data and colormap.
+
+        :param Union[None,~silx.gui.colors.Colormap] colormap:
+           The colormap for which to compute the autoscale range.
+           If None, the default, the colormap of the item is used
+        :return: (vmin, vmax) range (vmin and /or vmax might be `None`)
+        """
         if colormap is None:
             colormap = self.getColormap()
-        if colormap is None:
+
+        if colormap is None or self.__data is None:
             return None, None
+
         normalization = colormap.getNormalization()
-        data = self._getDataForAutoRange()
-        if data is None:
-            return None, None
-        key = normalization, id(data)
+        if normalization not in self.__cacheColormapRange:
+            self.__cacheColormapRange[normalization] = \
+                colormap._computeAutoscaleRange(self.__data)
 
-        cached = self._cachedDataRange
-        if cached is not None:
-            if cached[0] == key:
-                return cached[1]
-
-        dataRange = colormap.computeDataRange(data)
-        self._cachedDataRange = (key, dataRange)
-        return dataRange
-
-    def _getDataForAutoRange(self):
-        raise NotImplementedError()
+        return self.__cacheColormapRange[normalization]
 
 
 class SymbolMixIn(ItemMixInBase):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -494,7 +494,11 @@ class ColormapMixIn(ItemMixInBase):
         self.__data = None if data is None else numpy.array(data, copy=copy)
         self.__cacheColormapRange = {}  # Reset cache
 
-    def _getColormappedData(self, copy=True):
+        colormap = self.getColormap()
+        if None in (colormap.getVMin(), colormap.getVMax()):
+            self._colormapChanged()
+
+    def getColormappedData(self, copy=True):
         """Returns the data used to compute the displayed colors
 
         :param bool copy: True to get a copy,

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -386,6 +386,7 @@ class ImageData(ImageBase, ColormapMixIn):
                 'Converting complex image to absolute value to plot it.')
             data = numpy.absolute(data)
         self._data = data
+        self._setColormappedData(data, copy=False)
 
         if alternative is not None:
             alternative = numpy.array(alternative, copy=copy)
@@ -410,9 +411,6 @@ class ImageData(ImageBase, ColormapMixIn):
                 plot._invalidateDataRange()
 
         self._updated(ItemChangedType.DATA)
-
-    def _getDataForAutoRange(self):
-        return self._data
 
 
 class ImageRgba(ImageBase):

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -752,6 +752,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
         self.__cacheRegularGridInfo = None
 
         self._value = value
+        self._setColormappedData(value, copy=False)
 
         if alpha is not None:
             # Make sure alpha is an array of float in [0, 1]
@@ -768,6 +769,3 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
         # call self._updated + plot._invalidateDataRange()
         PointsBase.setData(self, x, y, xerror, yerror, copy)
-
-    def _getDataForAutoRange(self):
-        return self._value

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -693,7 +693,7 @@ class _ColormapBaseProxyRow(ProxyRow):
         """
         item = self.item()
         if item is not None and self._colormap is not None:
-            return self._colormap.getColormapRange(item._getDataRange())
+            return self._colormap.getColormapRange(item)
         else:
             return 1, 100  # Fallback
 

--- a/silx/gui/plot3d/items/image.py
+++ b/silx/gui/plot3d/items/image.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -118,7 +118,7 @@ class ImageData(_Image, ColormapMixIn):
                           False to use as is (do not modify!).
         """
         self._image.setData(data, copy=copy)
-        ColormapMixIn._setRangeFromData(self, self.getData(copy=False))
+        self._setColormappedData(self.getData(copy=False), copy=False)
         self._updated(ItemChangedType.DATA)
 
     def getData(self, copy=True):

--- a/silx/gui/plot3d/items/mesh.py
+++ b/silx/gui/plot3d/items/mesh.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -312,8 +312,7 @@ class ColormapMesh(_MeshBase, ColormapMixIn):
                 copy=copy)
         self._setMesh(mesh)
 
-        # Store data range info
-        ColormapMixIn._setRangeFromData(self, self.getValueData(copy=False))
+        self._setColormappedData(self.getValueData(copy=False), copy=False)
 
     def getData(self, copy=True):
         """Get the mesh geometry.

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -111,7 +111,6 @@ class ColormapMixIn(_ColormapMixIn):
     def __init__(self, sceneColormap=None):
         super(ColormapMixIn, self).__init__()
 
-        self._dataRange = None
         self.__sceneColormap = sceneColormap
         self._syncSceneColormap()
 

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -120,37 +120,6 @@ class ColormapMixIn(_ColormapMixIn):
         self._syncSceneColormap()
         super(ColormapMixIn, self)._colormapChanged()
 
-    def _setRangeFromData(self, data=None):
-        """Compute the data range the colormap should use from provided data.
-
-        :param data: Data set from which to compute the range or None
-        """
-        if data is None or data.size == 0:
-            dataRange = None
-        else:
-            dataRange = min_max(data, min_positive=True, finite=True)
-            if dataRange.minimum is None:  # Only non-finite data
-                dataRange = None
-
-            if dataRange is not None:
-                min_positive = dataRange.min_positive
-                if min_positive is None:
-                    min_positive = float('nan')
-                dataRange = dataRange.minimum, min_positive, dataRange.maximum
-
-        self._dataRange = dataRange
-
-        colormap = self.getColormap()
-        if None in (colormap.getVMin(), colormap.getVMax()):
-            self._colormapChanged()
-
-    def _getDataRange(self):
-        """Returns the data range as used in the scene for colormap
-
-        :rtype: Union[List[float],None]
-        """
-        return self._dataRange
-
     def _setSceneColormap(self, sceneColormap):
         """Set the scene colormap to sync with Colormap object.
 
@@ -171,8 +140,7 @@ class ColormapMixIn(_ColormapMixIn):
 
             self.__sceneColormap.colormap = colormap.getNColors()
             self.__sceneColormap.norm = colormap.getNormalization()
-            range_ = colormap.getColormapRange(data=self._dataRange)
-            self.__sceneColormap.range_ = range_
+            self.__sceneColormap.range_ = colormap.getColormapRange(self)
 
 
 class ComplexMixIn(_ComplexMixIn):

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -100,7 +100,7 @@ class Scatter3D(DataItem3D, ColormapMixIn, SymbolMixIn):
         self._scatter.setAttribute('z', z, copy=copy)
         self._scatter.setAttribute('value', value, copy=copy)
 
-        ColormapMixIn._setRangeFromData(self, self.getValueData(copy=False))
+        self._setColormappedData(self.getValueData(copy=False), copy=False)
         self._updated(ItemChangedType.DATA)
 
     def getData(self, copy=True):
@@ -366,8 +366,7 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn,
         self._cachedLinesIndices = None
         self._cachedTrianglesIndices = None
 
-        # Store data range info
-        ColormapMixIn._setRangeFromData(self, self.getValueData(copy=False))
+        self._setColormappedData(self.getValueData(copy=False), copy=False)
 
         self._updateScene()
 

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -93,7 +93,12 @@ class CutPlane(Item3D, ColormapMixIn, InterpolationMixIn, PlaneMixIn):
 
         # Store data range info as 3-tuple of values
         self._dataRange = range_
-        self._setColormappedData(self._data, copy=False)
+        if range_ is None:
+            range_ = None, None, None
+        self._setColormappedData(self._data, copy=False,
+                                 min_=range_[0],
+                                 minPositive=range_[1],
+                                 max_=range_[2])
 
         self._updated(ItemChangedType.DATA)
 


### PR DESCRIPTION
This PR reworks the min/max cache of the colormap (method renaming, change the was to provide the data to compute the range), renames method to make them private (except for `getColormappedData` which already existed in `plot3d` colormapped items), makes the ColorBar works with both data and item.
It also makes it work for 2D complex image and plot3d.

The way to pass already known min/max is not nice, it would be better to have a generic API for that at the item level... but it would need a bit of thinking and probably quite a few changes.